### PR TITLE
literal filters

### DIFF
--- a/src/ch.usi.inf.nodeprof.test/js/minitests/foo.js
+++ b/src/ch.usi.inf.nodeprof.test/js/minitests/foo.js
@@ -1,0 +1,4 @@
+function foo(a){
+}
+
+foo(1);

--- a/src/ch.usi.inf.nodeprof/js/analysis/literal-filter/function-literal.js
+++ b/src/ch.usi.inf.nodeprof/js/analysis/literal-filter/function-literal.js
@@ -1,3 +1,5 @@
+// DO NOT INSTRUMENT
+
 function LiteralFilter(){
   this.literal = function(iid, val, undef, type){
     console.log(J$.iidToLocation(iid), type, val);

--- a/src/ch.usi.inf.nodeprof/js/analysis/literal-filter/function-literal.js
+++ b/src/ch.usi.inf.nodeprof/js/analysis/literal-filter/function-literal.js
@@ -4,7 +4,7 @@ function LiteralFilter(){
   this.literal = function(iid, val, undef, type){
     console.log(J$.iidToLocation(iid), type, val);
   }
-  this.literal.types = "FunctionLiteral";
+  this.literal.types = ["FunctionLiteral"];
 }
 
 J$.addAnalysis(new LiteralFilter());

--- a/src/ch.usi.inf.nodeprof/js/analysis/literal-filter/function-literal.js
+++ b/src/ch.usi.inf.nodeprof/js/analysis/literal-filter/function-literal.js
@@ -1,0 +1,8 @@
+function LiteralFilter(){
+  this.literal = function(iid, val, undef, type){
+    console.log(J$.iidToLocation(iid), type, val);
+  }
+  this.literal.types = "FunctionLiteral";
+}
+
+J$.addAnalysis(new LiteralFilter());

--- a/src/ch.usi.inf.nodeprof/js/analysis/literal-filter/minitests.foo.js.expected
+++ b/src/ch.usi.inf.nodeprof/js/analysis/literal-filter/minitests.foo.js.expected
@@ -1,0 +1,8 @@
+(src/ch.usi.inf.nodeprof.test/js/minitests/foo.js:1:2:6:2) FunctionLiteral function (exports, require, module, __filename, __dirname) { function foo(a){
+}
+
+foo(1);
+
+}
+(src/ch.usi.inf.nodeprof.test/js/minitests/foo.js:1:63:2:2) FunctionLiteral function foo(a){
+}

--- a/src/ch.usi.inf.nodeprof/js/analysis/trivial/emptyTemplate.js
+++ b/src/ch.usi.inf.nodeprof/js/analysis/trivial/emptyTemplate.js
@@ -31,14 +31,16 @@
          * This callback is called after the creation of a literal. A literal can be a function
          * literal, an object literal, an array literal, a number, a string, a boolean, a regular
          * expression, null, NaN, Infinity, or undefined.
+         *
+         * hasGetterSetter is always undefined, can be computed with val (kept for Jalangi compability)
+         * literalType is a new argument provided by NodeProf showing the type of literal
          **/
-        this.literal = function (iid, val, 
-          /* hasGetterSetter is not computed by NodeProf as it can be computed with val, we keep this arg for Jalangi's compability */ hasGetterSetter, 
-          /* literalType is a new argument provided by NodeProf showing the type of literal */ literalType) {
+        this.literal = function (iid, val, hasGetterSetter, literalType) {
             return {result: val};
         };
-        // optional literal type filter: by specifying the types in a string split by ',', only given types of literals will be instrumented
-        this.literal.types = "ObjectLiteral,ArrayLiteral,FunctionLiteral,NumericLiteral,BooleanLiteral,StringLiteral,NullLiteral,UndefinedLiteral,RegExpLiteral";
+        // optional literal type filter: by specifying the types in an array, only given types of literals will be instrumented
+        this.literal.types = ["ObjectLiteral", "ArrayLiteral", "FunctionLiteral", "NumericLiteral", "BooleanLiteral", "StringLiteral",
+            "NullLiteral", "UndefinedLiteral", "RegExpLiteral"];
 
         /**
          * These callbacks are called before and after a property of an object is accessed.

--- a/src/ch.usi.inf.nodeprof/js/analysis/trivial/emptyTemplate.js
+++ b/src/ch.usi.inf.nodeprof/js/analysis/trivial/emptyTemplate.js
@@ -32,9 +32,13 @@
          * literal, an object literal, an array literal, a number, a string, a boolean, a regular
          * expression, null, NaN, Infinity, or undefined.
          **/
-        this.literal = function (iid, val, hasGetterSetter) {
+        this.literal = function (iid, val, 
+          /* hasGetterSetter is not computed by NodeProf as it can be computed with val, we keep this arg for Jalangi's compability */ hasGetterSetter, 
+          /* literalType is a new argument provided by NodeProf showing the type of literal */ literalType) {
             return {result: val};
         };
+        // optional literal type filter: by specifying the types in a string split by ',', only given types of literals will be instrumented
+        this.literal.types = "ObjectLiteral,ArrayLiteral,FunctionLiteral,NumericLiteral,BooleanLiteral,StringLiteral,NullLiteral,UndefinedLiteral,RegExpLiteral";
 
         /**
          * These callbacks are called before and after a property of an object is accessed.

--- a/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/handlers/LiteralEventHandler.java
+++ b/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/handlers/LiteralEventHandler.java
@@ -31,13 +31,6 @@ public abstract class LiteralEventHandler extends BaseSingleTagEventHandler {
     }
 
     /**
-     * TODO
-     */
-    public boolean hasSetterGetter() {
-        return false;
-    }
-
-    /**
      *
      * @return type of the literal, including ObjectLiteral, ArrayLiteral, FunctionLiteral,
      *         NumericLiteral, BooleanLiteral, StringLiteral, NullLiteral, UndefinedLiteral,

--- a/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/jalangi/factory/AbstractFactory.java
+++ b/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/jalangi/factory/AbstractFactory.java
@@ -25,6 +25,8 @@ import com.oracle.truffle.api.nodes.DirectCallNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.object.DynamicObject;
 import com.oracle.truffle.js.runtime.GraalJSException;
+import com.oracle.truffle.js.runtime.builtins.JSAbstractArray;
+import com.oracle.truffle.js.runtime.builtins.JSArray;
 import com.oracle.truffle.js.runtime.builtins.JSFunction;
 import com.oracle.truffle.js.runtime.objects.Null;
 import com.oracle.truffle.js.runtime.objects.Undefined;
@@ -64,6 +66,15 @@ public abstract class AbstractFactory implements
             return null;
         else
             return ret.toString();
+    }
+
+    @TruffleBoundary
+    protected static Object[] readArray(DynamicObject cb, String name) {
+        Object ret = readCBProperty(cb, name);
+        if (JSArray.isJSArray(ret)) {
+            return JSAbstractArray.toArray((DynamicObject) ret);
+        }
+        return null;
     }
 
     @TruffleBoundary

--- a/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/jalangi/factory/AbstractFactory.java
+++ b/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/jalangi/factory/AbstractFactory.java
@@ -17,11 +17,17 @@ package ch.usi.inf.nodeprof.jalangi.factory;
 
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.interop.ForeignAccess;
+import com.oracle.truffle.api.interop.Message;
+import com.oracle.truffle.api.interop.UnknownIdentifierException;
+import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.nodes.DirectCallNode;
+import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.object.DynamicObject;
 import com.oracle.truffle.js.runtime.GraalJSException;
 import com.oracle.truffle.js.runtime.builtins.JSFunction;
 import com.oracle.truffle.js.runtime.objects.Null;
+import com.oracle.truffle.js.runtime.objects.Undefined;
 
 import ch.usi.inf.nodeprof.analysis.AnalysisFactory;
 import ch.usi.inf.nodeprof.handlers.BaseEventHandlerNode;
@@ -39,6 +45,46 @@ public abstract class AbstractFactory implements
     protected final Object[] postArguments;
 
     protected final String jalangiCallback;
+
+    // used to read the callback object for configuration
+    protected static final Node read = Message.READ.createNode();
+
+    protected static boolean readBoolean(DynamicObject cb, String name) {
+        Object ret = readCBProperty(cb, name);
+        if (ret == null)
+            return false;
+        else
+            return ret instanceof Boolean && (Boolean) ret; // unchecked
+    }
+
+    @TruffleBoundary
+    protected static String readString(DynamicObject cb, String name) {
+        Object ret = readCBProperty(cb, name);
+        if (ret == null)
+            return null;
+        else
+            return ret.toString();
+    }
+
+    @TruffleBoundary
+    protected static boolean isPropertyUndefined(DynamicObject cb, String name) {
+        Object ret = readCBProperty(cb, name);
+        if (ret == null)
+            return true;
+        else
+            return ret == Undefined.instance;
+    }
+
+    protected static Object readCBProperty(DynamicObject cb, String name) {
+        if (cb == null)
+            return null;
+        try {
+            Object val = ForeignAccess.sendRead(read, cb, name);
+            return val == null ? null : val;
+        } catch (UnknownIdentifierException | UnsupportedMessageException e) {
+            return null;
+        }
+    }
 
     public AbstractFactory(String jalangiCallback, Object jalangiAnalysis, DynamicObject pre,
                     DynamicObject post, int numPreArguments, int numPostArguments) {
@@ -112,8 +158,8 @@ public abstract class AbstractFactory implements
      * call from Java to Jalangi JavaScript
      *
      * @param callNode
-     * @param args
-     * @param isPre TODO
+     * @param isPre pre or post callback
+     * @param iid source section id
      */
     protected void directCall(DirectCallNode callNode, boolean isPre, int iid) {
         if (nestedControl)

--- a/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/jalangi/factory/LiteralFactory.java
+++ b/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/jalangi/factory/LiteralFactory.java
@@ -15,37 +15,78 @@
  *******************************************************************************/
 package ch.usi.inf.nodeprof.jalangi.factory;
 
+import java.util.ArrayList;
+
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.EventContext;
 import com.oracle.truffle.api.nodes.DirectCallNode;
 import com.oracle.truffle.api.object.DynamicObject;
+import com.oracle.truffle.js.nodes.instrumentation.JSTags.LiteralExpressionTag;
+import com.oracle.truffle.js.runtime.objects.Undefined;
 
 import ch.usi.inf.nodeprof.handlers.BaseEventHandlerNode;
 import ch.usi.inf.nodeprof.handlers.LiteralEventHandler;
+import ch.usi.inf.nodeprof.utils.Logger;
 
 public class LiteralFactory extends AbstractFactory {
+    // an array of filters
+    final private ArrayList<String> types;
 
+    @TruffleBoundary
     public LiteralFactory(Object jalangiAnalysis, DynamicObject post) {
-        super("literal", jalangiAnalysis, null, post, -1, 3);
+        super("literal", jalangiAnalysis, null, post, -1, 4);
+
+        /*
+         * as hasGetterSetter is a not always used feature and can be computed from the returned
+         * literal object we don't pass any hasGetterOrSetter but for compatibility to Jalangi, we
+         * still keep this argument in the hook.
+         */
+        setPostArguments(2, Undefined.instance);
+
+        if (isPropertyUndefined(post, "types")) {
+            types = null;
+        } else {
+            String literalTypes = readString(post, "types"); // get types filter separated by ','
+            if (literalTypes == null || literalTypes.isEmpty()) {
+                types = null;
+            } else {
+                types = new ArrayList<String>();
+                for (String type : literalTypes.split(",")) {
+                    if (type.isEmpty())
+                        continue;
+                    try {
+                        LiteralExpressionTag.Type.valueOf(type);
+                        types.add(type);
+                    } catch (IllegalArgumentException e) {
+                        Logger.warning("Ignored invalid type " + type + "given for the literal callback");
+                    }
+                }
+            }
+        }
+    }
+
+    @TruffleBoundary
+    protected boolean isValidType(String someType) {
+        // always return true if no type filter is given
+        if (types == null || types.size() == 0)
+            return true;
+        return types.indexOf(someType) >= 0;
     }
 
     @Override
     public BaseEventHandlerNode create(EventContext context) {
         return new LiteralEventHandler(context) {
-            @Child DirectCallNode postCall = createPostCallNode();
-
-            @Override
-            public void executePre(VirtualFrame frame, Object[] inputs) {
-
-            }
+            private final boolean skip = !isValidType(getLiteralType());
+            @Child DirectCallNode postCall = skip ? null : createPostCallNode();
 
             @Override
             public void executePost(VirtualFrame frame, Object result,
                             Object[] inputs) {
-                if (post != null) {
+                if (post != null && !skip) {
                     setPostArguments(0, getSourceIID());
                     setPostArguments(1, convertResult(result));
-                    setPostArguments(2, this.hasSetterGetter());
+                    setPostArguments(3, getLiteralType());
                     directCall(postCall, false, getSourceIID());
                 }
             }

--- a/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/jalangi/factory/LiteralFactory.java
+++ b/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/jalangi/factory/LiteralFactory.java
@@ -59,7 +59,7 @@ public class LiteralFactory extends AbstractFactory {
                         LiteralExpressionTag.Type.valueOf(type);
                         types.add(type);
                     } catch (IllegalArgumentException e) {
-                        Logger.warning("Ignored invalid type " + type + "given for the literal callback");
+                        Logger.warning("Ignored invalid type " + type + " given for the literal callback");
                     }
                 }
             }


### PR DESCRIPTION
The changes include an extra argument in the literal callback showing the type of literal, and an optional filter to instrument only given literal types.

The added feature is documented here:
https://github.com/Haiyang-Sun/nodeprof.js/blob/literal-filter/src/ch.usi.inf.nodeprof/js/analysis/trivial/emptyTemplate.js#L30-L41

And tested here:
https://github.com/Haiyang-Sun/nodeprof.js/tree/literal-filter/src/ch.usi.inf.nodeprof/js/analysis/literal-filter

The added feature is fully compatible with the existing analyses written with the previous version. 