### PR TITLE
Add a new API ```J$.nativeLog```

### DIFF
--- a/src/ch.usi.inf.nodeprof/js/analysis/api/api.js
+++ b/src/ch.usi.inf.nodeprof/js/analysis/api/api.js
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright 2018 Dynamic Analysis Group, Università della Svizzera Italiana (USI)
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+//DO NOT INSTRUMENT
+(function(sandbox){
+  J$.nativeLog('default');
+  J$.nativeLog('debug', J$.nativeLog.DEBUG); // unchecked: debug off in tests
+  J$.nativeLog('info', J$.nativeLog.INFO);
+  J$.nativeLog('warning', J$.nativeLog.WARNING); // unchecked: emits to stderr
+  J$.nativeLog('error', J$.nativeLog.ERROR); // unchecked: emits to stderr
+  J$.nativeLog('neg level', -1);
+  J$.nativeLog('string level', "1");
+}
+)(J$);

--- a/src/ch.usi.inf.nodeprof/js/analysis/api/minitests.invoke.js.expected
+++ b/src/ch.usi.inf.nodeprof/js/analysis/api/minitests.invoke.js.expected
@@ -1,0 +1,4 @@
+[i] default
+[i] info
+[i] neg level
+[i] string level

--- a/src/ch.usi.inf.nodeprof/js/analysis/builtin-feature/analysis.js
+++ b/src/ch.usi.inf.nodeprof/js/analysis/builtin-feature/analysis.js
@@ -19,17 +19,17 @@
   function TestBuiltin() {
     function getLocation(iid) {
       if (process.config.variables.graalvm)
-        return  sandbox.iidToLocation(iid);
+        return sandbox.iidToLocation(iid);
       else
         return sandbox.iidToLocation(sandbox.sid, iid);
     }
     this.builtinEnter = function(builtinName, func, base, args){
       if(builtinName && builtinName.indexOf("Promise") > -1){
-        console.log("builtin used "+builtinName);
+        J$.nativeLog("builtin used "+builtinName);
       }
     }
     this.invokeFunPre = function(iid, func, base, args){
-      console.log("invoking "+getLocation(iid)+" "+func.name);
+      J$.nativeLog("invoking "+getLocation(iid)+" "+func.name);
     }
   };
   sandbox.addAnalysis(new TestBuiltin(), {includes:"builtin"});

--- a/src/ch.usi.inf.nodeprof/js/analysis/builtin-feature/minitests.builtin.js.expected
+++ b/src/ch.usi.inf.nodeprof/js/analysis/builtin-feature/minitests.builtin.js.expected
@@ -1,8 +1,8 @@
-invoking (src/ch.usi.inf.nodeprof.test/js/minitests/builtin.js:16:9:21:2) Promise
-builtin used Promise
-invoking (src/ch.usi.inf.nodeprof.test/js/minitests/builtin.js:19:5:19:16) 
-invoking (src/ch.usi.inf.nodeprof.test/js/minitests/builtin.js:22:1:22:28) then
-builtin used Promise.prototype.then
-builtin used Promise
-invoking (src/ch.usi.inf.nodeprof.test/js/minitests/builtin.js:22:13:22:27) bound log
+[i] invoking (src/ch.usi.inf.nodeprof.test/js/minitests/builtin.js:16:9:21:2) Promise
+[i] builtin used Promise
+[i] invoking (src/ch.usi.inf.nodeprof.test/js/minitests/builtin.js:19:5:19:16) 
+[i] invoking (src/ch.usi.inf.nodeprof.test/js/minitests/builtin.js:22:1:22:28) then
+[i] builtin used Promise.prototype.then
+[i] builtin used Promise
+[i] invoking (src/ch.usi.inf.nodeprof.test/js/minitests/builtin.js:22:13:22:27) bound log
 10

--- a/src/ch.usi.inf.nodeprof/js/jalangi.js
+++ b/src/ch.usi.inf.nodeprof/js/jalangi.js
@@ -24,6 +24,12 @@ J$={};
   try {
     sandbox.adapter = __jalangiAdapter;
     sandbox.deprecatedIIDUsed = false;
+    /*
+     * J$.nativeLog(msg)
+     * - print the message string using the logger (i.e., System.out) inside the engine
+     * - consider using this function instead of console.log in the analysis in case you 
+     *   want to dump messages while instrumenting some internal library or builtins
+     */
     sandbox.nativeLog = function(str) {
       __jalangiAdapter.nativeLog(str);
     }

--- a/src/ch.usi.inf.nodeprof/js/jalangi.js
+++ b/src/ch.usi.inf.nodeprof/js/jalangi.js
@@ -24,6 +24,9 @@ J$={};
   try {
     sandbox.adapter = __jalangiAdapter;
     sandbox.deprecatedIIDUsed = false;
+    sandbox.nativeLog = function(str) {
+      __jalangiAdapter.nativeLog(str);
+    }
     sandbox.iidToLocation = function(iid, _deprecatedIID){
       if(_deprecatedIID) {
         if(!sandbox.deprecatedIIDUsed){

--- a/src/ch.usi.inf.nodeprof/js/jalangi.js
+++ b/src/ch.usi.inf.nodeprof/js/jalangi.js
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright 2018 Dynamic Analysis Group, Università della Svizzera Italiana (USI)
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,14 +26,19 @@ J$={};
     sandbox.adapter = __jalangiAdapter;
     sandbox.deprecatedIIDUsed = false;
     /*
-     * J$.nativeLog(msg)
-     * - print the message string using the logger (i.e., System.out) inside the engine
-     * - consider using this function instead of console.log in the analysis in case you 
+     * J$.nativeLog(msg, logLevel)
+     * - print the message string using the logger (i.e., System.out/err) inside the engine
+     * - default log level is INFO
+     * - consider using this function instead of console.log in the analysis in case you
      *   want to dump messages while instrumenting some internal library or builtins
      */
-    sandbox.nativeLog = function(str) {
-      __jalangiAdapter.nativeLog(str);
+    sandbox.nativeLog = function(str, logLevel) {
+      __jalangiAdapter.nativeLog(...arguments);
     }
+    sandbox.nativeLog.DEBUG = 0;
+    sandbox.nativeLog.INFO = 1;
+    sandbox.nativeLog.WARNING = 2;
+    sandbox.nativeLog.ERROR = 3;
     sandbox.iidToLocation = function(iid, _deprecatedIID){
       if(_deprecatedIID) {
         if(!sandbox.deprecatedIIDUsed){

--- a/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/jalangi/JalangiAdapterMessageResolution.java
+++ b/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/jalangi/JalangiAdapterMessageResolution.java
@@ -99,8 +99,16 @@ public class JalangiAdapterMessageResolution {
                     }
                 }
             } else if (identifier.equals("nativeLog")) {
-                if (arguments.length == 1) {
-                    Logger.info(arguments[0]);
+                Logger.Level level = Logger.Level.INFO;
+                if (arguments.length >= 2) {
+                    int i = convertIID(arguments[1]);
+                    Logger.Level[] enumValues = Logger.Level.values();
+                    if (i >= 0 && i < enumValues.length) {
+                        level = enumValues[i];
+                    }
+                }
+                if (arguments.length > 0) {
+                    Logger.log(arguments[0], level);
                     return 0;
                 }
             } else if (identifier.equals("valueOf")) {

--- a/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/jalangi/JalangiAdapterMessageResolution.java
+++ b/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/jalangi/JalangiAdapterMessageResolution.java
@@ -98,6 +98,11 @@ public class JalangiAdapterMessageResolution {
                         throw UnsupportedTypeException.raise(e, arguments);
                     }
                 }
+            } else if (identifier.equals("nativeLog")) {
+                if (arguments.length == 1) {
+                    Logger.info(arguments[0]);
+                    return 0;
+                }
             } else if (identifier.equals("valueOf")) {
                 return "jalangi-adapter";
             } else if (identifier.equals("onReady")) {

--- a/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/utils/Logger.java
+++ b/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/utils/Logger.java
@@ -23,6 +23,13 @@ import com.oracle.truffle.api.source.SourceSection;
 import com.oracle.truffle.js.runtime.GraalJSException;
 
 public class Logger {
+    public enum Level {
+        DEBUG,   // 0
+        INFO,    // 1
+        WARNING, // 2
+        ERROR    // 3
+    }
+
     private static PrintStream out = System.out;
     private static PrintStream err = System.err;
 
@@ -39,6 +46,23 @@ public class Logger {
     @TruffleBoundary
     private static void print(PrintStream stream, String tag, SourceSection sourceSection, Object msg) {
         stream.printf("[%s] %s: %s\n", tag, SourceMapping.makeLocationString(sourceSection).toString(), msg.toString());
+    }
+
+    public static void log(Object msg, Level l) {
+        switch (l) {
+            case DEBUG:
+                debug(msg);
+                break;
+            case INFO:
+                info(msg);
+                break;
+            case WARNING:
+                warning(msg);
+                break;
+            case ERROR:
+                error(msg);
+                break;
+        }
     }
 
     public static void info(Object msg) {


### PR DESCRIPTION
- added support and test for ```J$.nativeLog(msg)```; 
- using ```J$.nativeLog(msg)``` instead of ```console.log``` in the analysis can avoid recursion caused by instrumenting some internal libraries or builtin used by ```console.log```.