### PR TITLE
remove static source filters as SVM loads classes differently

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,10 @@ before_script:
 script:
   - mx sforceimports
   - mx build
+  - cd ../graal/vm
+  - mx --dy nodeprof,/substratevm --force-bash-launchers=true --disable-polyglot build
+  - cd -
+  - mx test-specific --svm cmd-exclude
   - mx test-all
 
 deploy:

--- a/mx.nodeprof/mx_nodeprof.py
+++ b/mx.nodeprof/mx_nodeprof.py
@@ -82,14 +82,19 @@ def _testJalangi(args, analysisHome, analysis, force=False, testsuites=[]):
                 else:
                     continue;
 
-            for initParam in words[1:]:
-                # extra config for J$.initParams
-                if ":" in initParam:
-                    analysisOpt += ["--initParam"];
-                    analysisOpt += [initParam];
+            mx.logv("analysis parameters from config: " + str(words[1:]))
+
+            # read analysis parameters from config
+            for w in words[1:]:
+                # ignore download URLs
+                if w.startswith('http'):
+                    continue
+                # detect --nodeprof.Foo=bar style parameters
+                if w.startswith('--nodeprof'):
+                    args += [w]
+                # otherwise treat as analysis (jalangi.js) parameters
                 else:
-                    print("init param should be key:value")
-                    print("config file "+f+" has an invalid init param "+initParam)
+                    analysisOpt += [w]
 
             analysisOpt += ["--analysis"];
             analysisOpt += [join(analysisHome, f)];

--- a/src/ch.usi.inf.nodeprof.test/src/ch/usi/inf/nodeprof/test/examples/tests/TrivialTest.java
+++ b/src/ch.usi.inf.nodeprof.test/src/ch/usi/inf/nodeprof/test/examples/tests/TrivialTest.java
@@ -34,7 +34,7 @@ public class TrivialTest extends BasicAnalysisTest {
 
     @Override
     public AnalysisFilterSourceList getFilter() {
-        return AnalysisFilterSourceList.getAll();
+        return AnalysisFilterSourceList.getFilter(AnalysisFilterSourceList.ScopeEnum.all);
     }
 
     /**

--- a/src/ch.usi.inf.nodeprof.test/src/ch/usi/inf/nodeprof/test/examples/tests/TypedArrayTest.java
+++ b/src/ch.usi.inf.nodeprof.test/src/ch/usi/inf/nodeprof/test/examples/tests/TypedArrayTest.java
@@ -91,6 +91,6 @@ public class TypedArrayTest extends BasicAnalysisTest {
 
     @Override
     public AnalysisFilterSourceList getFilter() {
-        return AnalysisFilterSourceList.getAll();
+        return AnalysisFilterSourceList.getFilter(AnalysisFilterSourceList.ScopeEnum.all);
     }
 }

--- a/src/ch.usi.inf.nodeprof/js/analysis/cmd-exclude/analysis.js
+++ b/src/ch.usi.inf.nodeprof/js/analysis/cmd-exclude/analysis.js
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright 2018 Dynamic Analysis Group, Università della Svizzera Italiana (USI)
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+ //DO NOT INSTRUMENT
+((function(sandbox){
+  function FieldTest() {
+    console.log('Loading FieldTest..');
+    this.getField = function(iid, base, offset, val, isComputed, isOpAssign, isMethodCall) {
+      console.log('all code should be excluded!');
+    };
+  }
+  sandbox.addAnalysis(new FieldTest());
+}
+)(J$));

--- a/src/ch.usi.inf.nodeprof/js/analysis/cmd-exclude/config
+++ b/src/ch.usi.inf.nodeprof/js/analysis/cmd-exclude/config
@@ -1,0 +1,1 @@
+analysis.js --nodeprof.ExcludeSource=testFilter.js

--- a/src/ch.usi.inf.nodeprof/js/analysis/cmd-exclude/minitests.testFilter.js.expected
+++ b/src/ch.usi.inf.nodeprof/js/analysis/cmd-exclude/minitests.testFilter.js.expected
@@ -1,0 +1,1 @@
+Loading FieldTest..

--- a/src/ch.usi.inf.nodeprof/js/analysis/cmd/config
+++ b/src/ch.usi.inf.nodeprof/js/analysis/cmd/config
@@ -1,1 +1,1 @@
-analysis.js analysis:read,write,invokeFunPre
+analysis.js --initParam analysis:read,write,invokeFunPre

--- a/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/analysis/NodeProfAnalysis.java
+++ b/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/analysis/NodeProfAnalysis.java
@@ -230,7 +230,7 @@ public abstract class NodeProfAnalysis {
 
             // A built-in node has also the root tag, so we need a separate factory
             if (handlerMapping.containsKey(ProfiledTagEnum.BUILTIN)) {
-                SourceSectionFilter builtinFilter = SourceSectionFilter.newBuilder().tagIs(ProfiledTagEnum.BUILTIN.getTag()).sourceIs(AnalysisFilterSourceList.getBuiltinFilter()).build();
+                SourceSectionFilter builtinFilter = SourceSectionFilter.newBuilder().tagIs(ProfiledTagEnum.BUILTIN.getTag()).sourceIs(AnalysisFilterSourceList.getFilter(AnalysisFilterSourceList.ScopeEnum.builtin)).build();
                 getInstrumenter().attachExecutionEventFactory(
                                 builtinFilter,
                                 new ExecutionEventNodeFactory() {


### PR DESCRIPTION
Currently ```--nodeprof.ExcludeSource``` takes no effect in SVM build. As the class loading is different in SVM, the static field of the ```AnalysisFilterSourceList``` is loaded before the option is parsed in instrumentation setup. The fix is simply to get the source filter on-demand. 