### PR TITLE
make the iidToLocation string cache on-demand to save memory

### DIFF
--- a/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/utils/SourceMapping.java
+++ b/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/utils/SourceMapping.java
@@ -55,9 +55,6 @@ public abstract class SourceMapping {
         }
         int newIId = ++iidGen;
         assert (newIId < Integer.MAX_VALUE);
-        StringBuilder b = makeLocationString(sourceSection);
-
-        iidMap.put(newIId, b.toString());
         sourceSet.put(sourceSection, newIId);
         idToSource.put(newIId, sourceSection);
         return newIId;
@@ -65,7 +62,15 @@ public abstract class SourceMapping {
 
     @TruffleBoundary
     public static String getLocationForIID(int iid) {
-        return iidMap.get(iid);
+        if (iidMap.containsKey(iid)) {
+            return iidMap.get(iid);
+        } else if (idToSource.containsKey(iid)) {
+            String res = makeLocationString(idToSource.get(iid)).toString();
+            iidMap.put(iid, res);
+            return res;
+        } else {
+            return null;
+        }
     }
 
     @TruffleBoundary


### PR DESCRIPTION
Currently, the location string for an iid is created when allocating the iid, however, this could lead to unnecessary memory use if such iid is never used.
Cache it lazily on demand would solve this issue.