### PR TITLE
Wrap exception values in an object

### DIFF
--- a/src/ch.usi.inf.nodeprof.test/js/minitests/exitException.js
+++ b/src/ch.usi.inf.nodeprof.test/js/minitests/exitException.js
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright 2018 Dynamic Analysis Group, Università della Svizzera Italiana (USI)
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +23,10 @@ function bar(){
   throw new Error("this is an error");
 };
 
+function baz(){
+  throw undefined;
+};
+
 try {
   foo();
 }catch(e){
@@ -30,6 +35,12 @@ try {
 
 try {
   bar();
+}catch(e){
+  console.log("exception: "+e);
+}
+
+try {
+  baz();
 }catch(e){
   console.log("exception: "+e);
 }

--- a/src/ch.usi.inf.nodeprof/js/analysis/enter-exit/analysis.js
+++ b/src/ch.usi.inf.nodeprof/js/analysis/enter-exit/analysis.js
@@ -28,10 +28,10 @@
     };
 
     this.functionExit = function (iid, returnVal, wrappedExceptionVal) {
-      if(!wrappedExceptionVal) {
+      if(!('exception' in wrappedExceptionVal)) {
         console.log("functionExit: %s / %d", J$.iidToLocation(iid), arguments.length);
       }else {
-        console.log('functionExit with exception "%s(%s)": %s / %d', wrappedExceptionVal, typeof(wrappedExceptionVal),  J$.iidToLocation(iid), arguments.length);
+        console.log('functionExit with exception "%s(%s)": %s / %d', wrappedExceptionVal.exception, typeof(wrappedExceptionVal.exception),  J$.iidToLocation(iid), arguments.length);
       }
     };
 

--- a/src/ch.usi.inf.nodeprof/js/analysis/enter-exit/minitests.exitException.js.expected
+++ b/src/ch.usi.inf.nodeprof/js/analysis/enter-exit/minitests.exitException.js.expected
@@ -2,11 +2,13 @@ builtinEnter: Object.create / 4
 builtinExit: Object.create / 6
 builtinEnter: Object.create / 4
 builtinExit: Object.create / 6
-functionExit: (src/ch.usi.inf.nodeprof.test/js/minitests/exitException.js:1:1:37:4) / 3
-functionEnter: foo / (src/ch.usi.inf.nodeprof.test/js/minitests/exitException.js:17:1:19:2) / 4
-functionExit with exception "this is an exception(string)": (src/ch.usi.inf.nodeprof.test/js/minitests/exitException.js:17:1:19:2) / 3
+functionExit: (src/ch.usi.inf.nodeprof.test/js/minitests/exitException.js:1:1:48:4) / 3
+functionEnter: foo / (src/ch.usi.inf.nodeprof.test/js/minitests/exitException.js:18:1:20:2) / 4
+functionExit with exception "this is an exception(string)": (src/ch.usi.inf.nodeprof.test/js/minitests/exitException.js:18:1:20:2) / 3
 exception: this is an exception
-functionExit with exception "Error: this is an error(object)": (src/ch.usi.inf.nodeprof.test/js/minitests/exitException.js:21:1:23:2) / 3
+functionExit with exception "Error: this is an error(object)": (src/ch.usi.inf.nodeprof.test/js/minitests/exitException.js:22:1:24:2) / 3
 exception: Error: this is an error
-functionExit: (src/ch.usi.inf.nodeprof.test/js/minitests/exitException.js:1:2:37:2) / 3
+functionExit with exception "undefined(undefined)": (src/ch.usi.inf.nodeprof.test/js/minitests/exitException.js:26:1:28:2) / 3
+exception: undefined
+functionExit: (src/ch.usi.inf.nodeprof.test/js/minitests/exitException.js:1:2:48:2) / 3
 [ 'Object.create', 'foo' ]

--- a/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/jalangi/factory/BuiltinFactory.java
+++ b/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/jalangi/factory/BuiltinFactory.java
@@ -64,7 +64,7 @@ public class BuiltinFactory extends AbstractFactory {
                     setPostArguments(2, getReceiver(frame));
                     setPostArguments(3, makeArgs.executeArguments(getArguments(frame)));
                     setPostArguments(4, convertResult(result));
-                    setPostArguments(5, Undefined.instance);
+                    setPostArguments(5, createWrappedException(null));
                     directCall(postCall, false, getSourceIID());
                 }
             }
@@ -72,13 +72,12 @@ public class BuiltinFactory extends AbstractFactory {
             @Override
             public void executeExceptional(VirtualFrame frame, Throwable exception) {
                 if (isTarget && post != null) {
-                    Object exceptionValue = parseErrorObject(exception);
                     setPostArguments(0, this.getBuiltinName());
                     setPostArguments(1, getFunction(frame));
                     setPostArguments(2, getReceiver(frame));
                     setPostArguments(3, makeArgs.executeArguments(getArguments(frame)));
                     setPostArguments(4, Undefined.instance);
-                    setPostArguments(5, exceptionValue == null ? "Unknown Exception" : exceptionValue);
+                    setPostArguments(5, createWrappedException(exception));
                     directCall(postCall, false, getSourceIID());
                 }
             }

--- a/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/jalangi/factory/EvalFunctionFactory.java
+++ b/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/jalangi/factory/EvalFunctionFactory.java
@@ -55,7 +55,7 @@ public class EvalFunctionFactory extends AbstractFactory {
                 if (isTarget && post != null) {
                     setPostArguments(0, makeArgs.executeArguments(getArguments(frame)));
                     setPostArguments(1, convertResult(result));
-                    setPostArguments(2, Undefined.instance);
+                    setPostArguments(2, createWrappedException(null));
                     directCall(postCall, false, getSourceIID());
                 }
             }
@@ -63,10 +63,9 @@ public class EvalFunctionFactory extends AbstractFactory {
             @Override
             public void executeExceptional(VirtualFrame frame, Throwable exception) {
                 if (isTarget && post != null) {
-                    Object exceptionValue = parseErrorObject(exception);
                     setPostArguments(0, makeArgs.executeArguments(getArguments(frame)));
                     setPostArguments(1, Undefined.instance);
-                    setPostArguments(2, exceptionValue == null ? "Unknown Exception" : exceptionValue);
+                    setPostArguments(2, createWrappedException(exception));
                     directCall(postCall, false, getSourceIID());
                 }
             }

--- a/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/jalangi/factory/RootFactory.java
+++ b/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/jalangi/factory/RootFactory.java
@@ -67,7 +67,7 @@ public class RootFactory extends AbstractFactory {
                 if (!this.isBuiltin && post != null) {
                     setPostArguments(0, this.getSourceIID());
                     setPostArguments(1, convertResult(result));
-                    setPostArguments(2, Undefined.instance);
+                    setPostArguments(2, createWrappedException(null));
                     directCall(postCall, false, getSourceIID());
                 }
             }
@@ -77,11 +77,9 @@ public class RootFactory extends AbstractFactory {
                 if (isRegularExpression())
                     return;
                 if (!this.isBuiltin && post != null) {
-                    Object exceptionValue = parseErrorObject(exception);
                     setPostArguments(0, getSourceIID());
                     setPostArguments(1, Undefined.instance);
-                    setPostArguments(2, exceptionValue == null ? "Unknown Exception" : exceptionValue);
-
+                    setPostArguments(2, createWrappedException(exception));
                     directCall(postCall, false, getSourceIID());
                 }
             }


### PR DESCRIPTION
Allows NodeProf to support undefined being thrown.