### PR TITLE
Fix version of GraalJS dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ The tool is open source.
 Please feel free to report [issues](https://github.com/Haiyang-Sun/nodeprof.js/issues) or [contribute directly](https://github.com/Haiyang-Sun/nodeprof.js/pulls).
 
 ## GraalJS version
-The latest supported GraalVM version is 23.3.3.
+The latest supported GraalVM version is 22.3.3.
 
 ## Getting Started
 Get the [mx](https://github.com/graalvm/mx) build tool:


### PR DESCRIPTION
I made a typo in the commit message when I updated the depedency... :upside_down_face: 