### PR TITLE
Update GraalJS dependency to 23.0.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,8 @@ jobs:
       run: mx sversions
     - name: set up jdk
       run: |
-        mx fetch-jdk --java-distribution labsjdk-ce-11 --config ../graal/common.json --to $GITHUB_WORKSPACE --alias labsjdk-ce-11
-        echo "JAVA_HOME=$GITHUB_WORKSPACE/labsjdk-ce-11" >> $GITHUB_ENV
+        mx fetch-jdk --java-distribution labsjdk-ce-17 --config ../graal/common.json --to $GITHUB_WORKSPACE --alias labsjdk-ce-17
+        echo "JAVA_HOME=$GITHUB_WORKSPACE/labsjdk-ce-17" >> $GITHUB_ENV
     - name: style checks
       run: |
         mx checkstyle --primary

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ The tool is open source.
 Please feel free to report [issues](https://github.com/Haiyang-Sun/nodeprof.js/issues) or [contribute directly](https://github.com/Haiyang-Sun/nodeprof.js/pulls).
 
 ## GraalJS version
-The latest supported GraalVM version is 22.3.3.
+The latest supported GraalVM JavaScript version is 23.0.1.
 
 ## Getting Started
 Get the [mx](https://github.com/graalvm/mx) build tool:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ git clone https://github.com/graalvm/mx.git
 Use mx to download a JDK for building GraalVM and set the JAVA_HOME environment variable accordingly:
 
 ```
-mx fetch-jdk --java-distribution labsjdk-ce-11
+mx fetch-jdk --java-distribution labsjdk-ce-17
 export JAVA_HOME=PATH_TO_THE_DOWNLOADED_JDK
 ```
 

--- a/mx.nodeprof/suite.py
+++ b/mx.nodeprof/suite.py
@@ -6,7 +6,7 @@ suite = {
     "suites" : [
       {
         "name" : "graal-nodejs",
-        "version" : "0135a41c557bc1519d12028f22b819c27110e52c",
+        "version" : "b8af554c627475fb02bf2d7820239d5e9b488bcb",
         "subdir" : True,
         "urls" : [
           {"url" : "https://github.com/graalvm/graaljs.git", "kind" : "git"},

--- a/src/ch.usi.inf.nodeprof/js/analysis/asyncawait/minitests.async.js.expected
+++ b/src/ch.usi.inf.nodeprof/js/analysis/asyncawait/minitests.async.js.expected
@@ -2,16 +2,16 @@ functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:{{:program}})
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:{{:program}}) [Function (anonymous)] {}
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:{{module}})
 write (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:16:1:18:2) foo [AsyncFunction: foo]
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:20:11:20:71)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:20:1:20:72)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:20:2:20:71)
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:17:5:17:15)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:16:1:18:2)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:16:1:18:2)
 return (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:17:5:17:15) 42
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:16:1:18:2) 42 {}
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:17:5:17:15) Promise { 42 } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:16:1:18:2) Promise { 42 } {}
 awaitPre (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:20:27:20:38) <p0>
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:20:2:20:71) undefined { yield: true }
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:20:11:20:71) Promise { <pending> } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:20:1:20:72) Promise { <pending> } {}
 #####
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:{{module}}) undefined {}
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:20:2:20:71)
@@ -21,11 +21,11 @@ awaitPre (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:20:47:20:55) 43
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:20:2:20:71) undefined { yield: true }
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:20:2:20:71)
 awaitPost (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:20:47:20:55) 43 43 resolved
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:17:5:17:15)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:16:1:18:2)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:16:1:18:2)
 return (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:17:5:17:15) 42
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:16:1:18:2) 42 {}
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:17:5:17:15) Promise { 42 } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:16:1:18:2) Promise { 42 } {}
 awaitPre (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:20:58:20:69) <p1>
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:20:2:20:71) undefined { yield: true }
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async.js:20:2:20:71)

--- a/src/ch.usi.inf.nodeprof/js/analysis/asyncawait/minitests.async0.js.expected
+++ b/src/ch.usi.inf.nodeprof/js/analysis/asyncawait/minitests.async0.js.expected
@@ -3,26 +3,26 @@ functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:{{:program}})
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:{{module}})
 write (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:17:1:23:2) countTo6 [AsyncFunction: countTo6]
 write (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:25:1:27:2) main [AsyncFunction: main]
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:26:4:26:29)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:25:1:27:2)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:25:1:27:2)
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:17:28:23:2)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:17:1:23:2)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:17:1:23:2)
 binary 1 > 1 = false
 conditional (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:18:9:18:14) false
 binary 1 + 1 = 2
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:17:28:23:2)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:17:1:23:2)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:17:1:23:2)
 binary 2 > 1 = true
 conditional (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:18:9:18:14) true
 return (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:19:8:19:17) 2
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:17:1:23:2) 2 {}
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:17:28:23:2) Promise { 2 } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:17:1:23:2) Promise { 2 } {}
 awaitPre (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:21:16:21:37) <p0>
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:17:1:23:2) undefined { yield: true }
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:17:28:23:2) Promise { <pending> } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:17:1:23:2) Promise { <pending> } {}
 awaitPre (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:26:11:26:28) <p1>
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:25:1:27:2) undefined { yield: true }
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:26:4:26:29) Promise { <pending> } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:25:1:27:2) Promise { <pending> } {}
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:{{module}}) undefined {}
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:17:1:23:2)
 awaitPost (src/ch.usi.inf.nodeprof.test/js/minitests/async0.js:21:16:21:37) <p0> 2 resolved

--- a/src/ch.usi.inf.nodeprof/js/analysis/asyncawait/minitests.async1.js.expected
+++ b/src/ch.usi.inf.nodeprof/js/analysis/asyncawait/minitests.async1.js.expected
@@ -1,20 +1,20 @@
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async1.js:{{:program}})
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async1.js:{{:program}}) [Function (anonymous)] {}
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async1.js:{{module}})
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async1.js:18:27:21:6)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async1.js:17:1:22:2)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async1.js:18:5:21:6)
 binary 0 < 1 = true
 conditional (src/ch.usi.inf.nodeprof.test/js/minitests/async1.js:19:13:19:18) true
 binary 0 + 1 = 1
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async1.js:18:27:21:6)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async1.js:17:1:22:2)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async1.js:18:5:21:6)
 binary 1 < 1 = false
 conditional (src/ch.usi.inf.nodeprof.test/js/minitests/async1.js:19:13:19:18) false
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async1.js:18:5:21:6) undefined {}
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async1.js:18:27:21:6) Promise { undefined } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async1.js:17:1:22:2) Promise { undefined } {}
 awaitPre (src/ch.usi.inf.nodeprof.test/js/minitests/async1.js:20:20:20:34) <p0>
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async1.js:18:5:21:6) undefined { yield: true }
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async1.js:18:27:21:6) Promise { <pending> } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async1.js:17:1:22:2) Promise { <pending> } {}
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async1.js:{{module}}) undefined {}
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async1.js:18:5:21:6)
 awaitPost (src/ch.usi.inf.nodeprof.test/js/minitests/async1.js:20:20:20:34) <p0> undefined resolved

--- a/src/ch.usi.inf.nodeprof/js/analysis/asyncawait/minitests.async2.js.expected
+++ b/src/ch.usi.inf.nodeprof/js/analysis/asyncawait/minitests.async2.js.expected
@@ -2,15 +2,15 @@ functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async2.js:{{:program}}
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async2.js:{{:program}}) [Function (anonymous)] {}
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async2.js:{{module}})
 write (src/ch.usi.inf.nodeprof.test/js/minitests/async2.js:17:1:19:2) bar [AsyncFunction: bar]
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async2.js:22:5:26:6)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async2.js:21:1:27:3)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async2.js:21:2:27:2)
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async2.js:18:5:18:13)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async2.js:17:1:19:2)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async2.js:17:1:19:2)
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async2.js:17:1:19:2) undefined { exception: 1 }
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async2.js:18:5:18:13) Promise { <rejected> 1 } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async2.js:17:1:19:2) Promise { <rejected> 1 } {}
 awaitPre (src/ch.usi.inf.nodeprof.test/js/minitests/async2.js:23:9:23:20) <p0>
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async2.js:21:2:27:2) undefined { yield: true }
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async2.js:22:5:26:6) Promise { <pending> } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async2.js:21:1:27:3) Promise { <pending> } {}
 #####
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async2.js:{{module}}) undefined {}
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async2.js:21:2:27:2)

--- a/src/ch.usi.inf.nodeprof/js/analysis/asyncawait/minitests.async3.js.expected
+++ b/src/ch.usi.inf.nodeprof/js/analysis/asyncawait/minitests.async3.js.expected
@@ -3,64 +3,64 @@ functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:{{:program}})
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:{{module}})
 write (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2) countTo6 [AsyncFunction: countTo6]
 write (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:26:1:28:2) main [AsyncFunction: main]
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:27:4:27:29)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:26:1:28:2)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:26:1:28:2)
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:28:24:2)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2)
 hi 1!
 binary 1 > 5 = false
 conditional (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:19:9:19:14) false
 binary 1 + 1 = 2
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:28:24:2)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2)
 hi 1!
 binary 2 > 5 = false
 conditional (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:19:9:19:14) false
 binary 2 + 1 = 3
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:28:24:2)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2)
 hi 1!
 binary 3 > 5 = false
 conditional (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:19:9:19:14) false
 binary 3 + 1 = 4
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:28:24:2)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2)
 hi 1!
 binary 4 > 5 = false
 conditional (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:19:9:19:14) false
 binary 4 + 1 = 5
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:28:24:2)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2)
 hi 1!
 binary 5 > 5 = false
 conditional (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:19:9:19:14) false
 binary 5 + 1 = 6
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:28:24:2)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2)
 hi 1!
 binary 6 > 5 = true
 conditional (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:19:9:19:14) true
 return (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:20:8:20:17) 6
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2) 6 {}
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:28:24:2) Promise { 6 } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2) Promise { 6 } {}
 awaitPre (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:22:16:22:37) <p0>
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2) undefined { yield: true }
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:28:24:2) Promise { <pending> } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2) Promise { <pending> } {}
 awaitPre (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:22:16:22:37) <p1>
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2) undefined { yield: true }
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:28:24:2) Promise { <pending> } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2) Promise { <pending> } {}
 awaitPre (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:22:16:22:37) <p2>
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2) undefined { yield: true }
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:28:24:2) Promise { <pending> } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2) Promise { <pending> } {}
 awaitPre (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:22:16:22:37) <p3>
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2) undefined { yield: true }
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:28:24:2) Promise { <pending> } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2) Promise { <pending> } {}
 awaitPre (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:22:16:22:37) <p4>
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2) undefined { yield: true }
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:28:24:2) Promise { <pending> } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2) Promise { <pending> } {}
 awaitPre (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:27:11:27:28) <p5>
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:26:1:28:2) undefined { yield: true }
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:27:4:27:29) Promise { <pending> } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:26:1:28:2) Promise { <pending> } {}
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:{{module}}) undefined {}
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:17:1:24:2)
 awaitPost (src/ch.usi.inf.nodeprof.test/js/minitests/async3.js:22:16:22:37) <p0> 6 resolved

--- a/src/ch.usi.inf.nodeprof/js/analysis/asyncawait/minitests.async4.js.expected
+++ b/src/ch.usi.inf.nodeprof/js/analysis/asyncawait/minitests.async4.js.expected
@@ -4,24 +4,24 @@ functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:{{module}})
 write (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:17:1:21:2) func1 [AsyncFunction: func1]
 write (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:23:1:26:2) func2 [AsyncFunction: func2]
 write (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:28:1:31:2) func3 [AsyncFunction: func3]
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:17:25:21:2)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:17:1:21:2)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:17:1:21:2)
 func1 5
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:23:25:26:2)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:23:1:26:2)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:23:1:26:2)
 func2 5
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:28:25:31:2)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:28:1:31:2)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:28:1:31:2)
 func3 5
 return (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:30:5:30:14) 5
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:28:1:31:2) 5 {}
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:28:25:31:2) Promise { 5 } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:28:1:31:2) Promise { 5 } {}
 awaitPre (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:25:12:25:26) <p0>
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:23:1:26:2) undefined { yield: true }
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:23:25:26:2) Promise { <pending> } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:23:1:26:2) Promise { <pending> } {}
 awaitPre (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:19:5:19:19) <p1>
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:17:1:21:2) undefined { yield: true }
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:17:25:21:2) Promise { <pending> } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:17:1:21:2) Promise { <pending> } {}
 ###########
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:{{module}}) undefined {}
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:23:1:26:2)
@@ -30,18 +30,18 @@ return (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:25:5:25:27) 5
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:23:1:26:2) 5 {}
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:17:1:21:2)
 awaitPost (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:19:5:19:19) <p1> 5 resolved
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:23:25:26:2)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:23:1:26:2)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:23:1:26:2)
 func2 5
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:28:25:31:2)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:28:1:31:2)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:28:1:31:2)
 func3 5
 return (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:30:5:30:14) 5
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:28:1:31:2) 5 {}
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:28:25:31:2) Promise { 5 } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:28:1:31:2) Promise { 5 } {}
 awaitPre (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:25:12:25:26) <p2>
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:23:1:26:2) undefined { yield: true }
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:23:25:26:2) Promise { <pending> } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:23:1:26:2) Promise { <pending> } {}
 awaitPre (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:20:5:20:19) <p3>
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:17:1:21:2) undefined { yield: true }
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/async4.js:23:1:26:2)

--- a/src/ch.usi.inf.nodeprof/js/analysis/asyncawait/minitests.await.js.expected
+++ b/src/ch.usi.inf.nodeprof/js/analysis/asyncawait/minitests.await.js.expected
@@ -2,48 +2,48 @@ functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:{{:program}})
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:{{:program}}) [Function (anonymous)] {}
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:{{module}})
 write (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:1:11:2) foo [AsyncFunction: foo]
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:13:12:13:18)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:13:1:13:19)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:13:2:13:18)
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:23:11:2)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:1:11:2)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:1:11:2)
 awaitPre (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:4:15:4:22) <p0>
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:1:11:2) undefined { yield: true }
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:23:11:2) Promise { <pending> } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:1:11:2) Promise { <pending> } {}
 return (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:13:12:13:18) Promise { <pending> }
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:13:2:13:18) Promise { <pending> } {}
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:13:12:13:18) Promise { <pending> } {}
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:14:12:14:18)
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:13:1:13:19) Promise { <pending> } {}
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:14:1:14:19)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:14:2:14:18)
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:23:11:2)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:1:11:2)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:1:11:2)
 awaitPre (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:4:15:4:22) <p1>
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:1:11:2) undefined { yield: true }
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:23:11:2) Promise { <pending> } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:1:11:2) Promise { <pending> } {}
 return (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:14:12:14:18) Promise { <pending> }
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:14:2:14:18) Promise { <pending> } {}
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:14:12:14:18) Promise { <pending> } {}
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:15:12:15:18)
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:14:1:14:19) Promise { <pending> } {}
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:15:1:15:19)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:15:2:15:18)
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:23:11:2)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:1:11:2)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:1:11:2)
 awaitPre (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:4:15:4:22) 43
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:1:11:2) undefined { yield: true }
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:23:11:2) Promise { <pending> } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:1:11:2) Promise { <pending> } {}
 return (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:15:12:15:18) Promise { <pending> }
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:15:2:15:18) Promise { <pending> } {}
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:15:12:15:18) Promise { <pending> } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:15:1:15:19) Promise { <pending> } {}
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:16:32:20:2)
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:16:32:20:2) undefined {}
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:16:12:16:18)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:16:1:16:19)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:16:2:16:18)
-asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:23:11:2)
+asyncEnter (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:1:11:2)
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:1:11:2)
 awaitPre (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:4:15:4:22) <p2>
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:1:11:2) undefined { yield: true }
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:23:11:2) Promise { <pending> } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:1:11:2) Promise { <pending> } {}
 return (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:16:12:16:18) Promise { <pending> }
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:16:2:16:18) Promise { <pending> } {}
-asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:16:12:16:18) Promise { <pending> } {}
+asyncExit (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:16:1:16:19) Promise { <pending> } {}
 functionExit@ (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:{{module}}) undefined {}
 functionEnter@ (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:1:1:11:2)
 awaitPost (src/ch.usi.inf.nodeprof.test/js/minitests/await.js:4:15:4:22) <p0> 44 resolved

--- a/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/jalangi/factory/InitialRootFactory.java
+++ b/src/ch.usi.inf.nodeprof/src/ch/usi/inf/nodeprof/jalangi/factory/InitialRootFactory.java
@@ -53,7 +53,7 @@ public class InitialRootFactory extends AbstractFactory {
         }
         if (seenSources.add(source)) {
             // getCharacters() needs to be behind boundary
-            return Strings.fromCharSequence(source.getCharacters());
+            return Strings.fromJavaString(source.getCharacters().toString());
         }
         return null;
     }


### PR DESCRIPTION
This update was quite simple. (:crossed_fingers:)

The positions for iids passed to `asyncFunction{Enter,Exit}` became more accurate.